### PR TITLE
✨ feat(bindings): Remove unused home controller import

### DIFF
--- a/lib/bindings/bindings.dart
+++ b/lib/bindings/bindings.dart
@@ -1,7 +1,6 @@
 import 'package:get/get.dart';
 
 import '../controllers/controllers.dart';
-import '../controllers/home/home_controller.dart';
 import '../services/token_service.dart';
 
 class HomeBindings extends Bindings {


### PR DESCRIPTION
Removes the unused import of the `home_controller.dart` file from the
`bindings.dart` file. This change simplifies the imports and removes
unnecessary code.