### PR TITLE
✨ feat(home): Add logout functionality

### DIFF
--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -1,9 +1,11 @@
 import 'package:control_examination/configurations/constants/assets.dart';
+import 'package:control_examination/controllers/controllers.dart';
 import 'package:control_examination/resource_manager/index.dart';
+import 'package:control_examination/services/services.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
-import '../../controllers/home/home_controller.dart';
+import '../../routes_manger.dart';
 
 class HomeScreen extends GetView<HomeController> {
   const HomeScreen({super.key});
@@ -187,7 +189,13 @@ class HomeScreen extends GetView<HomeController> {
                         ),
                       ),
                       InkWell(
-                        onTap: () {},
+                        onTap: () async {
+                          await Get.find<ProfileController>()
+                              .deleteProfileFromHiveBox();
+                          await Get.find<TokenService>()
+                              .deleteTokenModelFromHiveBox();
+                          Get.offAllNamed(Routes.loginRoute);
+                        },
                         child: Icon(
                           Icons.logout_outlined,
                           color: ColorManager.white,


### PR DESCRIPTION
Adds a new logout functionality to the home screen. Users can now
log out of the app by tapping the logout icon. This change
includes the following:

- Adds an `onTap` function to the logout icon that calls the
  `deleteProfileFromHiveBox()` and `deleteTokenModelFromHiveBox()`
  methods to remove the user's profile and token data from the
  Hive box.
- Navigates the user to the login screen after the data has been
  deleted using the `Get.offAllNamed()` method.