### PR TITLE
🔧 feat(dependencies): add socket_io_client and logging packages

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -248,6 +248,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.19.0"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.7"
   json_annotation:
     dependency: transitive
     description:
@@ -296,6 +304,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
+  logging:
+    dependency: transitive
+    description:
+      name: logging
+      sha256: "623a88c9594aa774443aa3eb2d41807a48486b5613e67599fb4c41c0ad47c340"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
   matcher:
     dependency: transitive
     description:
@@ -421,6 +437,22 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.99"
+  socket_io_client:
+    dependency: "direct main"
+    description:
+      name: socket_io_client
+      sha256: ede469f3e4c55e8528b4e023bdedbc20832e8811ab9b61679d1ba3ed5f01f23b
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.3+1"
+  socket_io_common:
+    dependency: transitive
+    description:
+      name: socket_io_common
+      sha256: "2ab92f8ff3ebbd4b353bf4a98bee45cc157e3255464b2f90f66e09c4472047eb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.3"
   source_span:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   dartz: ^0.10.1
   carousel_slider: ^4.2.1
   intl: ^0.19.0
+  socket_io_client: ^2.0.3+1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Adds the `socket_io_client` and `logging` packages to the project's
dependencies. This will enable the application to connect to a socket.io
server and provide logging functionality.

The changes include:

- Add `socket_io_client` and `socket_io_common` packages to `pubspec.yaml`
  and `pubspec.lock`
- Add `logging` package to `pubspec.lock`

These changes are necessary to implement real-time communication features
and provide improved logging capabilities for the application.