### PR TITLE
🎨 feat(home_screen): Improve exam time handling logic

### DIFF
--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -113,12 +113,7 @@ class HomeScreen extends GetView<HomeController> {
                                         .studentExamsResModel!.exams!.length,
                                     (index) => InkWell(
                                       onTap: () {
-                                        if (DateTime.parse(controller
-                                                    .studentExamsResModel
-                                                    ?.exams?[index]
-                                                    .examMission
-                                                    ?.endTime ??
-                                                DateTime.now().toString())
+                                        if (DateTime.parse(controller.studentExamsResModel?.exams?[index].examMission?.endTime ?? DateTime.now().toString())
                                             .toUtc()
                                             .isBefore(DateTime.now().toUtc())) {
                                           MyAwesomeDialogue(
@@ -128,17 +123,38 @@ class HomeScreen extends GetView<HomeController> {
                                                   dialogType: DialogType.error)
                                               .showDialogue(
                                                   Get.key.currentContext!);
-                                        } else if (DateTime.parse(controller
-                                                    .studentExamsResModel
-                                                    ?.exams?[index]
-                                                    .examMission
-                                                    ?.startTime ??
-                                                DateTime.now().toString())
+                                        } else if (DateTime.parse(controller.studentExamsResModel?.exams?[index].examMission?.startTime ?? DateTime.now().toString())
                                             .toUtc()
-                                            .isBefore(DateTime.now()
+                                            .isAfter(DateTime.now().toUtc())) {
+                                          Get.toNamed(
+                                              Routes.studentExamScreenWaiting);
+                                        } else if (DateTime.parse(controller
+                                                        .studentExamsResModel
+                                                        ?.exams?[index]
+                                                        .examMission
+                                                        ?.startTime ??
+                                                    DateTime.now().toString())
                                                 .toUtc()
-                                                .subtract(const Duration(
-                                                    minutes: 15)))) {
+                                                .difference(
+                                                    DateTime.now().toUtc()) <
+                                            const Duration(minutes: 15)) {
+                                          Get.find<ExamMissionController>()
+                                              .saveExamMissionToHiveBox(
+                                                  controller
+                                                      .studentExamsResModel!
+                                                      .exams![index]
+                                                      .examMission!);
+                                          Get.toNamed(
+                                              Routes.studentExamScreenWaiting);
+                                        } else if (DateTime.parse(controller
+                                                        .studentExamsResModel
+                                                        ?.exams?[index]
+                                                        .examMission
+                                                        ?.startTime ??
+                                                    DateTime.now().toString())
+                                                .toUtc()
+                                                .difference(DateTime.now().toUtc()) <
+                                            const Duration(minutes: 5)) {
                                           Get.find<ExamMissionController>()
                                               .saveExamMissionToHiveBox(
                                                   controller


### PR DESCRIPTION
Improve the logic for handling exam time in the home screen. The changes
include:

- Check if the exam start time is in the future, and navigate to the
  waiting screen if so.
- Check if the exam start time is within 15 minutes, save the exam
  mission to the Hive box, and navigate to the waiting screen.
- Check if the exam start time is within 5 minutes, save the exam
  mission to the Hive box, and navigate to the waiting screen.
- Simplify the logic for checking if the exam has ended, by directly
  comparing the end time with the current time.

These changes improve the user experience by providing more accurate
information about the exam status and streamlining the navigation to the
appropriate screens.