### PR TITLE
🔖 feat(exam-mission-controller): add barcode management

### DIFF
--- a/lib/controllers/exam_mission_controller.dart
+++ b/lib/controllers/exam_mission_controller.dart
@@ -6,6 +6,8 @@ import 'package:hive_flutter/hive_flutter.dart';
 
 class ExamMissionController extends GetxController {
   ExamMission? _cachedExamMission;
+  String? _barcode;
+  String? get barcode => _barcode ?? getBarcodeFromHiveBox();
 
   ExamMission? get cachedExamMission =>
       _cachedExamMission ?? getExamMissionFromHiveBox();
@@ -13,6 +15,13 @@ class ExamMissionController extends GetxController {
   void deleteExamMissionFromHiveBox() {
     _cachedExamMission = null;
     Hive.box('ExamMission').clear();
+  }
+
+  String? getBarcodeFromHiveBox() {
+    _barcode = Hive.box('ExamMission').containsKey("Barcode")
+        ? Hive.box('ExamMission').get('Barcode')
+        : null;
+    return _barcode;
   }
 
   ExamMission? getExamMissionFromHiveBox() {
@@ -23,10 +32,14 @@ class ExamMissionController extends GetxController {
     return _cachedExamMission;
   }
 
-  void saveExamMissionToHiveBox(ExamMission cachedExamMission) {
+  void saveExamMissionToHiveBox({
+    required ExamMission examMission,
+    required String barcode,
+  }) {
     _cachedExamMission = cachedExamMission;
     update();
     Hive.box('ExamMission')
-        .put('ExamMission', jsonEncode(cachedExamMission.toJson()));
+        .put('ExamMission', jsonEncode(examMission.toJson()));
+    Hive.box('ExamMission').put('Barcode', barcode);
   }
 }


### PR DESCRIPTION
Adds a new method `getBarcodeFromHiveBox()` to retrieve the barcode
from the Hive box. Modifies the `saveExamMissionToHiveBox()` method to
also save the barcode to the Hive box.