### PR TITLE
✨ feat: Update attendance status color logic

### DIFF
--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -208,7 +208,7 @@ class HomeScreen extends GetView<HomeController> {
                                                     color: exam.isCheating == 1
                                                         ? ColorManager.ornage
                                                         : exam.attendanceStatusId ==
-                                                                1
+                                                                13
                                                             ? ColorManager.green
                                                             : DateTime.parse(exam
                                                                             .examMission


### PR DESCRIPTION
Updates the color logic for the attendance status display in the home
screen. The new logic checks for a status ID of 13 instead of 1 to
display the green color, indicating the exam has been attended.