### PR TITLE
🔥 feat(student_in_exam): clean up unused controllers

### DIFF
--- a/lib/controllers/student_exam/student_in_exam_controller.dart
+++ b/lib/controllers/student_exam/student_in_exam_controller.dart
@@ -67,8 +67,8 @@ class StudentInExamController extends FullLifeCycleController
 
   @override
   void onClose() {
-    // Get.delete<StudentQrCodeController>(force: true);
-    // Get.delete<StudentExamController>(force: true);
+    Get.delete<StudentQrCodeController>(force: true);
+    Get.delete<StudentExamController>(force: true);
 
     super.onClose();
   }


### PR DESCRIPTION
Removes the commented-out code that was deleting the
`StudentQrCodeController` and `StudentExamController` instances
on `onClose()`. This ensures that these controllers are properly
cleaned up when the `StudentInExamController` is closed, preventing
any potential memory leaks or other issues.