### PR TITLE
✨ feat(login): improve token storage and simplify profile saving

### DIFF
--- a/lib/controllers/login_controller.dart
+++ b/lib/controllers/login_controller.dart
@@ -45,11 +45,12 @@ class LoginController extends GetxController {
         isLogin = false;
       },
       (r) {
-        tokenService.saveTokenModelToHiveBox(TokenModel(
-          aToken: r.accessToken!,
-          rToken: r.refreshToken!,
-          dToken: DateTime.now().toIso8601String(),
-        ));
+        tokenService.saveTokenModelToHiveBox(
+          TokenModel(
+            aToken: r.accessToken!,
+            rToken: r.refreshToken!,
+          ),
+        );
         profileController.saveProfileToHiveBox(r.userProfile!);
         isLogin = true;
       },


### PR DESCRIPTION
Refactors the token storage process by removing the `dToken` field from the
`TokenModel` as it is unnecessary. Additionally, the profile saving process
has been simplified by directly storing the user profile in the Hive box,
eliminating the need for a separate operation.