### PR TITLE
🔖 feat: Bump app version to 1.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.0.1
+version: 1.0.0
 
 environment:
   sdk: ">=3.4.3 <4.0.0"


### PR DESCRIPTION
The changes in this commit update the app's version in the `pubspec.yaml`
file from `0.0.1` to `1.0.0`. This indicates that the app has reached a
stable version and is ready for a major release.