### PR TITLE
🔨 feat(firebase): update control examination staging URL

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -6,7 +6,7 @@
     "nis-control-4cd9d": {
       "hosting": {
         "control_examination": [
-          "control-examination"
+          "staging-control-examination"
         ]
       }
     }


### PR DESCRIPTION
Updates the control examination hosting URL in the .firebaserc
configuration file to use the `staging-control-examination` target
instead of the `control-examination` target.