### PR TITLE
✨ feat: ignore entire .vscode directory and add Firebase directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ migrate_working_dir/
 # The .vscode folder contains launch configuration and tasks you configure in
 # VS Code which you may wish to be included in version control, so this line
 # is commented out by default.
-.vscode/
+.vscode/*
 
 # Flutter/Dart/Pub related
 **/doc/api/
@@ -41,3 +41,7 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+
+# Firebase
+.firebase/*


### PR DESCRIPTION
Ignores the entire .vscode directory to avoid including local IDE configuration
files in version control. Adds a rule to ignore the .firebase directory, which
is used to store local Firebase emulator files.