### PR TITLE
feat(pubspec.lock): Update dependency versions

### DIFF
--- a/lib/controllers/student_exam/student_in_exam_controller.dart
+++ b/lib/controllers/student_exam/student_in_exam_controller.dart
@@ -1,16 +1,16 @@
 import 'dart:typed_data';
 
 import 'package:awesome_dialog/awesome_dialog.dart';
-import 'package:control_examination/routes_manger.dart';
+// import 'package:control_examination/routes_manger.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:pdf_render/pdf_render_widgets.dart';
 
-import '../../configurations/app_links.dart';
+// import '../../configurations/app_links.dart';
 import '../../resource_manager/ReusableWidget/show_dialogue.dart';
-import '../../resource_manager/enums/req_type_enum.dart';
-import '../../tools/response_handler.dart';
+// import '../../resource_manager/enums/req_type_enum.dart';
+// import '../../tools/response_handler.dart';
 import '../controllers.dart';
 
 /// student in exam controller

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -365,10 +365,10 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: a75164ade98cb7d24cfd0a13c6408927c6b217fa60dee5a7ff5c116a58f28918
+      sha256: "894f37107424311bdae3e476552229476777b8752c5a2a2369c0cb9a2d5442ef"
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.2"
+    version: "8.0.3"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -626,10 +626,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.4"
+    version: "14.2.5"
   web:
     dependency: transitive
     description:


### PR DESCRIPTION
Update the versions of the `vm_service` and `package_info_plus` dependencies to their latest versions.

The `vm_service` dependency is updated from version `14.2.4` to `14.2.5`, and the `package_info_plus` dependency is updated from version `8.0.2` to `8.0.3`.

These updates help ensure that the application is using the latest versions of these dependencies, which may include bug fixes, performance improvements, or new features.

feat(student_in_exam_controller): Remove unused imports

Remove the unused imports from the `student_in_exam_controller.dart` file. This helps to keep the codebase clean and maintainable by removing unnecessary dependencies.

The removed imports include `routes_manger.dart`, `app_links.dart`, `req_type_enum.dart`, and `response_handler.dart`. These changes do not affect the functionality of the application.