### PR TITLE
🏗️ refactor(firebase): remove cache control headers

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -9,22 +9,10 @@
     ],
     "headers": [
       {
-        "source": "**/*.html",
-        "headers": [
-          {
-            "key": "Cache-Control",
-            "value": "no-cache"
-          }
-        ]
+        "source": "**/*.html"
       },
       {
-        "source": "**/*.{js,css}",
-        "headers": [
-          {
-            "key": "Cache-Control",
-            "value": "max-age=0, no-cache, no-store, must-revalidate"
-          }
-        ]
+        "source": "**/*.{js,css}"
       }
     ],
     "frameworksBackend": {


### PR DESCRIPTION
The changes in this commit remove the cache control headers from the
firebase.json file. This is done to simplify the configuration and allow
the web server to handle caching of HTML, CSS, and JavaScript files
instead of setting these headers explicitly.