### PR TITLE
update-server-clock-and-student-exams

### DIFF
--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -206,8 +206,10 @@ class HomeScreen extends GetView<HomeController> {
                                                                       ?.endTime ??
                                                                   DateTime.now()
                                                                       .toString())
-                                                              .isBefore(DateTime
-                                                                  .now())) {
+                                                              .isBefore(controller
+                                                                      .serverDateTime ??
+                                                                  DateTime
+                                                                      .now())) {
                                                             MyAwesomeDialogue(
                                                               title:
                                                                   'Exam Ended',
@@ -219,19 +221,18 @@ class HomeScreen extends GetView<HomeController> {
                                                             ).showDialogue(Get
                                                                 .key
                                                                 .currentContext!);
-                                                          } else if (DateTime.parse(exam.examMission?.startTime ?? DateTime.now().toString())
-                                                                      .difference(
+                                                          } else if (DateTime.parse(exam.examMission?.startTime ?? DateTime.now().toString()).difference(
+                                                                      controller.serverDateTime ??
                                                                           DateTime
                                                                               .now()) <=
                                                                   const Duration(
                                                                     minutes: 5,
                                                                   ) ||
-                                                              DateTime.parse(
-                                                                      exam.examMission?.startTime ?? DateTime.now().toString())
-                                                                  .isBefore(DateTime.now())) {
+                                                              DateTime.parse(exam.examMission?.startTime ?? DateTime.now().toString())
+                                                                  .isBefore(controller.serverDateTime ?? DateTime.now())) {
                                                             Get.toNamed(Routes
                                                                 .studentExamScreenQRCode);
-                                                          } else if (DateTime.parse(exam.examMission?.startTime ?? DateTime.now().toString()).difference(DateTime.now()) <
+                                                          } else if (DateTime.parse(exam.examMission?.startTime ?? DateTime.now().toString()).difference(controller.serverDateTime ?? DateTime.now()) <
                                                               const Duration(
                                                                 minutes: 15,
                                                               )) {

--- a/lib/screens/student_exam_waiting/student_exam_waiting_screen.dart
+++ b/lib/screens/student_exam_waiting/student_exam_waiting_screen.dart
@@ -8,11 +8,12 @@ import '../../controllers/controllers.dart';
 import '../../routes_manger.dart';
 
 class StudentExamWaitingScreen extends GetView<StudentExamController> {
-  final int _start = DateTime.parse(Get.find<ExamMissionController>()
+  final int _start = Get.find<HomeController>()
+      .serveClock!
+      .difference(DateTime.parse(Get.find<ExamMissionController>()
           .cachedExamMission!
           .startTime
-          .toString())
-      .difference(DateTime.now())
+          .toString()))
       .inSeconds
       .abs(); // Countdown starting value
 


### PR DESCRIPTION
Here is a suggested pull request description based on the provided context:

```
## Description

This pull request includes the following changes:

1. **Refactor server clock timer in Home Controller**
   - Simplified the `serverClock` timer logic by using a single `update()` call within the timer callback
   - Extracted the server clock initialization logic into a separate `getServerClock()` method, handling the API response and starting the timer
   - Added a new `serverDateTime` property to store the parsed server clock datetime

2. **Improved exam time validation in Home Screen**
   - Used the server datetime provided by the Home Controller instead of the local device datetime to ensure accurate time comparisons
   - Checked if the exam end time is before the server datetime instead of the local device datetime
   - Checked if the exam start time is within 5 minutes or before the server datetime instead of the local device datetime
   - Checked if the exam start time is less than 15 minutes away from the server datetime instead of the local device datetime

3. **Improved countdown timer logic in Student Exam Waiting Screen**
   - Changed the countdown timer logic to use the server clock, as retrieved from the Home Controller, ensuring the countdown is accurate and synchronized with the server time

These changes improve the reliability and accuracy of the server clock, exam time validation, and countdown timer functionality in the application.
```